### PR TITLE
Win/Linux Sourcemod path

### DIFF
--- a/adastral/adastral.cpp
+++ b/adastral/adastral.cpp
@@ -2,12 +2,20 @@
 
 #include <kachemak/kachemak.hpp>
 
+using namespace std;
 
 int main()
 {
-	Kachemak kachemak = Kachemak("C:\\Program Files (x86)\\Steam\\steamapps\\sourcemods\\", "tf2classic");
-	printf("Latest version: %s - Installed version: %s\n", kachemak.GetLatestVersion().value().szVersion.c_str(), kachemak.GetInstalledVersion().c_str());
+	filesystem::path sourcemodPath = Utility::GetSteamSourcemodPath();
+	if (sourcemodPath.empty())
+	{
+		printf("Error: Steam installation not found");
+		return 1;
+	}
 
+	Kachemak kachemak = Kachemak(sourcemodPath, "tf2classic");
+	printf("Latest version: %s - Installed version: %s\n", kachemak.GetLatestVersion().value().szVersion.c_str(), kachemak.GetInstalledVersion().c_str());
+	
 	kachemak.Update();
 	return 0;
 }

--- a/adastral/utility/utility.cpp
+++ b/adastral/utility/utility.cpp
@@ -164,6 +164,8 @@ std::filesystem::path Utility::GetSteamSourcemodPath()
 	RegGetValueA(HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath", RRF_RT_ANY, nullptr, &valueData, &valueLen);
 	return std::filesystem::path(valueData) / "steamapps\\sourcemods";
 #else
-	return std::filesystem::path();
+	//Return normal steam path or use sym link version
+	auto normal_steam_linux =  std::filesystem::path("~/.local/share/Steam/steamapps/sourcemods");
+	return std::filesystem::exists(normal_steam_linux) ? normal_steam_linux : std::filesystem::path("~/.steam/steam/steamapps/sourcemods");
 #endif
 }

--- a/adastral/utility/utility.cpp
+++ b/adastral/utility/utility.cpp
@@ -155,3 +155,15 @@ int Utility::ExtractTar(const std::string& szInputFile, const std::filesystem::p
 
     return 0;
 }
+
+std::filesystem::path Utility::GetSteamSourcemodPath()
+{
+#if _WIN32
+	char valueData[MAX_PATH];
+	DWORD valueLen = MAX_PATH;
+	RegGetValueA(HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\Valve\\Steam", "InstallPath", RRF_RT_ANY, nullptr, &valueData, &valueLen);
+	return std::filesystem::path(valueData) / "steamapps\\sourcemods";
+#else
+	return std::filesystem::path();
+#endif
+}

--- a/adastral/utility/utility.hpp
+++ b/adastral/utility/utility.hpp
@@ -16,4 +16,9 @@ class Utility
     static int DeleteDirectoryContent(const std::filesystem::path& dir);
     static int ExtractZStd(const std::string& szInputFile, const std::string& szOutputDirectory);
     static int ExtractTar(const std::string& szInputFile, const std::filesystem::path& szOutputDirectory);
+
+    /// <summary>
+    /// Get steam sourcemod folder as path
+    /// </summary>
+    static std::filesystem::path GetSteamSourcemodPath();
 };


### PR DESCRIPTION
This adds finding steam install path via the registry.
Linux version tries to use the presumed path, or the ~/.steam symlink.

Tested only with msvc on windows.